### PR TITLE
Add an optional variable to disable date change

### DIFF
--- a/bin/ATLAS
+++ b/bin/ATLAS
@@ -67,7 +67,7 @@ rm -f $SSH_ERR
 
 # Try to get the date from a previous incarnation
 $LOAD_STORAGE_CURRENT_TIME
-if [ -f $STATUS_DIR/currenttime.txt ]
+if [ -f $STATUS_DIR/currenttime.txt ] && [ "$ENABLE_DATE_CHANGE" != "false" ]
 then
 	t=`cat $STATUS_DIR/currenttime.txt`
 	echo Setting time to $t


### PR DESCRIPTION
This PR adds a check if a date change is disabled.  

Reason:
In the case of Turris this date change will fail because it uses older
the version of busybox date command with different parameters. Without setting variable all script should behave in the same way. 

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>