### PR TITLE
Add new arch turris-sw-probe

### DIFF
--- a/bin/ATLAS
+++ b/bin/ATLAS
@@ -22,6 +22,10 @@ if [ X"${DEVICE_NAME}" = X"centos-sw-probe" ]
 then
 	. /usr/local/atlas/bin/arch/centos-sw-probe/redhat-ATLAS.sh
 	echo "DEVICE_NAME=${DEVICE_NAME}"
+elif [ X"${DEVICE_NAME}" = X"turris-sw-probe" ]
+then
+	. /usr/libexec/atlas-probe-scripts/bin/arch/turris-sw-probe/turris-ATLAS.sh
+        echo "DEVICE_NAME=${DEVICE_NAME}"
 elif [ X"${DEVICE_NAME}" = X"nanopi-neo-plus2" ]
 then
 	. /home/atlas/bin/arch/openwrt-atlas-probev4/openwrt-nanopi-ATLAS.sh

--- a/bin/arch/turris-sw-probe/turris-ATLAS.sh
+++ b/bin/arch/turris-sw-probe/turris-ATLAS.sh
@@ -1,0 +1,89 @@
+if [ -n "$ATLAS_BASE" ]
+then
+	BASE_DIR="$ATLAS_BASE"
+	export ATLAS_BASE
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/common-pre.sh
+
+# Commands
+SET_DATE_FROM_CURRENTTIME_TXT=:
+MANUAL_UPGRADE_CMD=:
+TRY_UPGRADE_CMD=:
+FINDPID_SSH_CMD=findpid_ssh
+KILL_PERDS_CMD=kill_perds
+KILL_SSH_CMD=kill_ssh
+KILL_TELNETD_CMD=kill_telnetd
+MOUNT_FS_CMD=:
+SETUP_NETWORK_CMD=:
+NTPCLIENT_CMD=:
+SU_CMD=""
+CHOWN_FOR_MSM=:
+CHMOD_FOR_MSM=chmod_for_msm
+SET_HOSTNAME=:
+
+# For OpenWRT we need telnetd to run as root.
+telnetd()
+{
+	$SU_CMD $BB_BASE_DIR/usr/sbin/telnetd "$@"
+}
+
+# Various files and directories
+: ${HOME:=/usr/libexec/atlas-probe-scripts}; export HOME	# Set HOME if it isn't set
+
+RESOLV_CONF=/etc/resolv.conf
+MODE_FILE=$BASE_DIR/state/mode
+
+# Other conf
+TELNETD_PORT=2023
+DHCP=False
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/turris-sw-probe/turris-common.sh
+
+# Directories
+STATE_DIR=$WRT_BASE_DIR/state; export STATE_DIR
+BB_BASE_DIR=/usr/libexec/atlas-probe; export BB_BASE_DIR
+BB_BIN_DIR=$BB_BASE_DIR/bin; export BB_BIN_DIR
+
+# Files
+REG_SERVERS_SOURCE=$WRT_ETC_DIR/reg_servers.sh
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/linux/linux-functions.sh
+
+chmod_for_msm()
+{
+	chmod -R g+rwX $BASE_DIR/data
+}
+
+# Get ethernet address
+get_ether_addr
+
+# Create ssh keys if they are not there yet.
+if [ ! -f "$BASE_DIR"/etc/probe_key ]; then
+    name=$(hostname -s)
+    mkdir -p "$BASE_DIR"/etc
+    ssh-keygen -t rsa -P '' -C turris-atlas -f "$BASE_DIR"/etc/probe_key
+    chown -R atlas:atlas "$BASE_DIR"/etc
+fi
+
+while :
+do
+	mode=$(cat $MODE_FILE)
+	case X$mode in
+	Xdev|Xtest|Xprod)
+		# Okay
+		if [ ! -f $REG_SERVERS ]
+		then
+			mkdir -p $BASE_DIR/bin
+			cp $REG_SERVERS_SOURCE.$mode $REG_SERVERS
+		fi
+	;;
+	*)
+		echo "Probe is not configured, mode $mode"
+		sos "Imode-$mode"
+		sleep 60
+		continue
+	;;
+	esac
+	break
+done

--- a/bin/arch/turris-sw-probe/turris-common.sh
+++ b/bin/arch/turris-sw-probe/turris-common.sh
@@ -1,0 +1,18 @@
+
+WRT_PROBE_SCRIPTS_DIR=/usr/libexec/atlas-probe-scripts
+WRT_BASE_DIR=/usr/libexec/atlas-probe; export WRT_BASE_DIR
+WRT_ETC_DIR=$WRT_PROBE_SCRIPTS_DIR/etc; export WRT_ETC_DIR
+BIN_DIR=$WRT_PROBE_SCRIPTS_DIR/bin
+ATLASINIT=$BB_BIN_DIR/atlasinit; export REG_INIT_BIN
+KNOWN_HOSTS_REG=$WRT_ETC_DIR/known_hosts.reg
+REG_SERVERS=$BASE_DIR/bin/reg_servers.sh
+
+# Commands
+SET_LEDS_CMD=log_status
+
+log_status()
+{
+	state="$1"
+	date_now="$(date +'%D %H:%M:%S')"
+	echo "$date_now $state" >>/tmp/log/ripe_sw_probe
+}

--- a/bin/arch/turris-sw-probe/turris-reginit.sh
+++ b/bin/arch/turris-sw-probe/turris-reginit.sh
@@ -1,0 +1,51 @@
+if [ -n "$ATLAS_BASE" ]
+then
+	BASE_DIR="$ATLAS_BASE"
+	export ATLAS_BASE
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/common-pre.sh
+
+# Directories
+
+# Commands
+CHECK_FOR_NEW_KERNEL_CMD=:
+INSTALL_FIRMWARE_CMD=:
+P_TO_R_INIT_CMD=p_to_r_init
+SSH_CMD=ssh
+SSH_CMD_EXEC=ssh_exec
+
+# Options
+SSH_OPT=''
+TELNETD_PORT=2023
+
+NETCONFIG_V4_DEST=$HOME/etc/netconfig_v4.sh
+NETCONFIG_V6_DEST=$HOME/etc/netconfig_v6.sh
+P_TO_R_INIT_IN=$STATUS_DIR/p_to_r_init.in.vol
+
+if [ ! -n "$STATE_FILE" ] ; then
+	echo "called without state file as argument"
+	STATE_FILE=$STATUS_DIR/reginit.vol
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/turris-sw-probe/turris-common.sh
+. /usr/libexec/atlas-probe-scripts/bin/arch/linux/linux-functions.sh
+
+get_arch()
+{
+	echo "fluffy"
+}
+
+get_sub_arch()
+{
+	echo "$SUB_ARCH"
+}
+
+p_to_r_init()
+{
+	{
+		echo P_TO_R_INIT
+		echo TOKEN_SPECS `get_arch` 1000 `cat $STATE_DIR/FIRMWARE_APPS_VERSION` `get_sub_arch`
+		echo REASON_FOR_REGISTRATION $1
+	} | tee $P_TO_R_INIT_IN
+}

--- a/bin/reginit.sh
+++ b/bin/reginit.sh
@@ -11,6 +11,9 @@ STATE_FILE=$1
 if [ X"${DEVICE_NAME}" = X"centos-sw-probe" ]
 then
 	. /usr/local/atlas/bin/arch/centos-sw-probe/redhat-reginit.sh
+elif [ X"${DEVICE_NAME}" = X"turris-sw-probe" ]
+then
+	. /usr/libexec/atlas-probe-scripts/bin/arch/turris-sw-probe/turris-reginit.sh
 elif [ X"${DEVICE_NAME}" = X"nanopi-neo-plus2" ]
 then
         . /home/atlas/bin/arch/openwrt-atlas-probev4/openwrt-nanopi-reginit.sh


### PR DESCRIPTION
This PR adds support for software probe to TurrisOS. It adds new arch **turris-sw-probe** and extends ATLAS and regint.sh arch detection.

 
Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>