### PR TITLE
Update .spec Requirements for CentOS8

### DIFF
--- a/build-config/centos/spec/atlasswprobe.spec.in
+++ b/build-config/centos/spec/atlasswprobe.spec.in
@@ -8,7 +8,7 @@ Release:        3%{?dist}
 License:        RIPE NCC
 Group:          Applications/Internet
 Source1:        src-COMMIT_ID.tar.gz
-Requires:       sudo %{?el6:daemontools} %{?el7:psmisc} %{?el8:psmisc} openssh-clients iproute %{?el7:sysvinit-tools} net-tools
+Requires:       sudo %{?el6:daemontools} %{?el7:psmisc} %{?el8:psmisc} openssh-clients iproute %{?el7:sysvinit-tools} %{?el8:procps-ng} net-tools
 BuildRequires:  rpm %{?el7:systemd} %{?el8:systemd} openssl-devel
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 


### PR DESCRIPTION
https://github.com/RIPE-NCC/ripe-atlas-software-probe/blob/96c0ab043b962de0e22d190acc979a6f1a34d489/bin/arch/linux/linux-functions.sh#L93 requires ```pidof``` which is now in https://centos.pkgs.org/7/centos-x86_64/procps-ng-3.3.10-26.el7.i686.rpm.html