### PR TITLE
Make ssh-keygen generate a 2048 bit key (on debian)

### DIFF
--- a/bin/arch/debian-sw-probe/debian-sw-probe-ATLAS.sh
+++ b/bin/arch/debian-sw-probe/debian-sw-probe-ATLAS.sh
@@ -63,7 +63,7 @@ ln -sf $RPM_BASE_DIR/state/FIRMWARE_APPS_VERSION $BASE_DIR/state/FIRMWARE_APPS_V
 if [ ! -f "$BASE_DIR"/etc/probe_key ]; then
     name=$(hostname -s)
     mkdir -p "$BASE_DIR"/etc
-    ssh-keygen -t rsa -P '' -C $name -f "$BASE_DIR"/etc/probe_key
+    ssh-keygen -t rsa -b 2048 -P '' -C $name -f "$BASE_DIR"/etc/probe_key
     chown -R atlas:atlas "$BASE_DIR"/etc
 fi
 


### PR DESCRIPTION
If this change isn't applied (or a new key isn't manually generated after install), user receives an error saying `The key is too long, a valid key is 2048-bit RSA key` when trying to register a probe.

I didn't touch centos here as I don't know if that defaults to 2048 or not. However, do let me know if you'd like me to add that into this PR too.