### PR TITLE
Allow ARM64 builds on debian packages

### DIFF
--- a/build-config/debian/bin/make-deb
+++ b/build-config/debian/bin/make-deb
@@ -107,6 +107,9 @@ case $(uname -m) in
 x86_64)
 	ARCH=amd64
 ;;
+aarch64)
+	ARCH=arm64
+;;
 armv7l)
 	ARCH=armhf
 ;;


### PR DESCRIPTION
I personally confirmed that it builds and installs fine, seems to run fine too, didn't verify that it's sending correct data (waiting on application # 28), but I can't see anything that'd be an issue.