### PR TITLE
Fixes build error if you are inside the git directory

### DIFF
--- a/build-config/debian/bin/make-deb
+++ b/build-config/debian/bin/make-deb
@@ -6,7 +6,11 @@ set -e
 stadir="$PWD/atlasswprobe-$VERSION"
 builddir="$PWD/atlasswprobe-$VERSION"-work
 
-srcdir="$PWD/ripe-atlas-software-probe"
+if [ -d "probe-busybox" ]; then
+        srcdir="$PWD"
+else
+        srcdir="$PWD/ripe-atlas-software-probe"
+fi
 
 atlas_local_rel="usr/local/atlas"
 var_atlas_rel="var/atlas-probe"


### PR DESCRIPTION
If you are inside the git directory the build fails because the make assumes you are outside of it.