### PR TITLE
INSTALL.rts updates

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -19,4 +19,4 @@ Currently only the Debian Build system includes support for amd64, arm64, and ar
 - ```./ripe-atlas-software-probe/build-config/debian/bin/make-deb```
 - This will leave the .deb in the current working directory.
 - ```dpkg -i atlasswprobe-??????.deb```
-
+- The public key will be stored in /var/atlas-probe/etc/probe_key.pub

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -14,7 +14,7 @@ Installation Instructions
 
 Currently only the Debian Build system includes support for amd64, arm64, and armhf.
 
-- ```apt update && apt install git tar fakeroot libssl-dev autoconf automake libtool build-essential```
+- ```apt update && apt install git tar fakeroot libssl-dev libcap2-bin autoconf automake libtool build-essential```
 - ```git clone --recursive https://github.com/RIPE-NCC/ripe-atlas-software-probe.git```
 - ```./ripe-atlas-software-probe/build-config/debian/bin/make-deb```
 - This will leave the .deb in the current working directory.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ Installation Instructions
 
 ##### To create a deb for Debian or Debian-based distros
 
-Currently only the Debian Build system includes support for arm64 and armhf
+Currently only the Debian Build system includes support for amd64, arm64, and armhf.
 
 - ```apt update && apt install git tar fakeroot libssl-dev autoconf automake libtool build-essential```
 - ```git clone --recursive https://github.com/RIPE-NCC/ripe-atlas-software-probe.git```

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -19,4 +19,4 @@ Currently only the Debian Build system includes support for amd64, arm64, and ar
 - ```./ripe-atlas-software-probe/build-config/debian/bin/make-deb```
 - This will leave the .deb in the current working directory.
 - ```dpkg -i atlasswprobe-??????.deb```
-- The public key will be stored in /var/atlas-probe/etc/probe_key.pub
+- The public key will be stored in ```/var/atlas-probe/etc/probe_key.pub```


### PR DESCRIPTION
Committing the changes discussed last week, all in INSTALL.rst:
- re-add 'amd64' to list of platforms
- add dependency missing from my Debian 9 build
- mention the location of the public key once generated