### PR TITLE
Make ssh-keygen generate a 2048 bit key

### DIFF
--- a/bin/arch/turris-sw-probe/turris-sw-probe-ATLAS.sh
+++ b/bin/arch/turris-sw-probe/turris-sw-probe-ATLAS.sh
@@ -62,7 +62,7 @@ get_ether_addr
 if [ ! -f "$BASE_DIR"/etc/probe_key ]; then
     name="$(hostname -s)"
     mkdir -p "$BASE_DIR"/etc
-    ssh-keygen -t rsa -P '' -C turris-atlas -f "$BASE_DIR"/etc/probe_key
+    ssh-keygen -t rsa -b 2048 -P '' -C turris-atlas -f "$BASE_DIR"/etc/probe_key
     chown -R atlas:atlas "$BASE_DIR"/etc
 fi
 


### PR DESCRIPTION
Same as https://github.com/RIPE-NCC/ripe-atlas-software-probe/pull/13 , but this time for Turris routers. My key is by default generated by RSA 3072 and when I want to submit my application for RIPE Atlas software probe, it says: `The key is too long, a valid key is 2048-bit RSA key`