### PR TITLE
Add software probe for OpenWrt

### DIFF
--- a/bin/arch/openwrt-sw-probe/openwrt-sw-probe-ATLAS.sh
+++ b/bin/arch/openwrt-sw-probe/openwrt-sw-probe-ATLAS.sh
@@ -1,0 +1,92 @@
+if [ -n "$ATLAS_BASE" ]
+then
+	BASE_DIR="$ATLAS_BASE"
+	export ATLAS_BASE
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/common-pre.sh
+
+# Commands
+SET_DATE_FROM_CURRENTTIME_TXT=:
+MANUAL_UPGRADE_CMD=:
+TRY_UPGRADE_CMD=:
+FINDPID_SSH_CMD=findpid_ssh
+KILL_PERDS_CMD=kill_perds
+KILL_SSH_CMD=kill_ssh
+KILL_TELNETD_CMD=kill_telnetd
+MOUNT_FS_CMD=:
+SETUP_NETWORK_CMD=:
+NTPCLIENT_CMD=:
+SU_CMD=""
+CHOWN_FOR_MSM=:
+CHMOD_FOR_MSM=chmod_for_msm
+SET_HOSTNAME=:
+
+# For OpenWRT we need telnetd to run as root.
+telnetd()
+{
+	$SU_CMD "$BB_BASE_DIR/usr/sbin/telnetd" "$@"
+}
+
+# Various files and directories
+: ${HOME:=/usr/libexec/atlas-probe-scripts}; export HOME	# Set HOME if it isn't set
+
+RESOLV_CONF=/etc/resolv.conf
+MODE_FILE=$BASE_DIR/state/mode
+
+# Other conf
+TELNETD_PORT=2023
+DHCP=False
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
+
+# Directories
+STATE_DIR=$WRT_BASE_DIR/state; export STATE_DIR
+BB_BASE_DIR=/usr/libexec/atlas-probe; export BB_BASE_DIR
+BB_BIN_DIR=$BB_BASE_DIR/bin; export BB_BIN_DIR
+
+# Files
+REG_SERVERS_SOURCE=$WRT_ETC_DIR/reg_servers.sh
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/linux/linux-functions.sh
+
+chmod_for_msm()
+{
+	chmod -R g+rwX "$BASE_DIR"/data
+}
+
+# Get ethernet address
+get_ether_addr
+
+# Set SOS_ID to the hash of the public key
+export SOS_ID="H$(hash_ssh_pubkey $BASE_DIR/etc/probe_key.pub)"
+
+# Create ssh keys if they are not there yet.
+if [ ! -f "$BASE_DIR"/etc/probe_key ]; then
+    name="$(uci -q get system.@system[0].hostname || echo -e openwrt)"
+    mkdir -p "$BASE_DIR"/etc
+    ssh-keygen -t rsa -b 4096 -P '' -C "$name" -f "$BASE_DIR"/etc/probe_key
+    chown -R atlas:atlas "$BASE_DIR"/etc
+fi
+
+while :
+do
+	mode=$(cat "$MODE_FILE")
+	case X$mode in
+	Xdev|Xtest|Xprod)
+		# Okay
+		if [ ! -f "$REG_SERVERS" ]
+		then
+			mkdir -p "$BASE_DIR"/bin
+			cp $REG_SERVERS_SOURCE.$mode $REG_SERVERS
+		fi
+	;;
+	*)
+		echo "Probe is not configured, mode $mode"
+		sos "Imode-$mode"
+		sleep 60
+		continue
+	;;
+	esac
+	break
+done

--- a/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
+++ b/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
@@ -1,0 +1,18 @@
+
+WRT_PROBE_SCRIPTS_DIR=/usr/libexec/atlas-probe-scripts
+WRT_BASE_DIR=/usr/libexec/atlas-probe; export WRT_BASE_DIR
+WRT_ETC_DIR=$WRT_PROBE_SCRIPTS_DIR/etc; export WRT_ETC_DIR
+BIN_DIR=$WRT_PROBE_SCRIPTS_DIR/bin
+ATLASINIT=$BB_BIN_DIR/atlasinit; export REG_INIT_BIN
+KNOWN_HOSTS_REG=$WRT_ETC_DIR/known_hosts.reg
+REG_SERVERS=$BASE_DIR/bin/reg_servers.sh
+
+# Commands
+SET_LEDS_CMD=log_status
+
+log_status()
+{
+	state="$1"
+	date_now="$(date +'%D %H:%M:%S')"
+	echo "$date_now $state" >>/tmp/log/ripe_sw_probe
+}

--- a/bin/arch/openwrt-sw-probe/openwrt-sw-probe-reginit.sh
+++ b/bin/arch/openwrt-sw-probe/openwrt-sw-probe-reginit.sh
@@ -1,0 +1,51 @@
+if [ -n "$ATLAS_BASE" ]
+then
+	BASE_DIR="$ATLAS_BASE"
+	export ATLAS_BASE
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/common-pre.sh
+
+# Directories
+
+# Commands
+CHECK_FOR_NEW_KERNEL_CMD=:
+INSTALL_FIRMWARE_CMD=:
+P_TO_R_INIT_CMD=p_to_r_init
+SSH_CMD=ssh
+SSH_CMD_EXEC=ssh_exec
+
+# Options
+SSH_OPT=''
+TELNETD_PORT=2023
+
+NETCONFIG_V4_DEST=$HOME/etc/netconfig_v4.sh
+NETCONFIG_V6_DEST=$HOME/etc/netconfig_v6.sh
+P_TO_R_INIT_IN=$STATUS_DIR/p_to_r_init.in.vol
+
+if [ ! -n "$STATE_FILE" ] ; then
+	echo "called without state file as argument"
+	STATE_FILE=$STATUS_DIR/reginit.vol
+fi
+
+. /usr/libexec/atlas-probe-scripts/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
+. /usr/libexec/atlas-probe-scripts/bin/arch/linux/linux-functions.sh
+
+get_arch()
+{
+	echo "fluffy"
+}
+
+get_sub_arch()
+{
+	echo "$SUB_ARCH"
+}
+
+p_to_r_init()
+{
+	{
+		echo P_TO_R_INIT
+		echo TOKEN_SPECS `get_arch` 1000 `cat $STATE_DIR/FIRMWARE_APPS_VERSION` `get_sub_arch`
+		echo REASON_FOR_REGISTRATION $1
+	} | tee $P_TO_R_INIT_IN
+}


### PR DESCRIPTION
This PR adds support for the software probe to OpenWrt. Right now it's similar to the Turris software probe, but it will probably diverge in the future. 

After merging this code I want to send the package to OpenWrt packages repository which will point to this code.

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>