### PR TITLE
added sudo where needed + ubuntu specific stuff

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -19,8 +19,14 @@ Installation Instructions
 
 Currently only the Debian Build system includes support for amd64, arm64, and armhf.
 
-- Get the needed tools: ``apt update && apt install git tar fakeroot libssl-dev libcap2-bin autoconf automake libtool build-essential``
+- Get the needed tools: ``sudo apt update && sudo apt install git tar fakeroot libssl-dev libcap2-bin autoconf automake libtool build-essential``
 - Clone the repo: ``git clone --recursive https://github.com/RIPE-NCC/ripe-atlas-software-probe.git``
 - Build the needed .deb file in the current working directory: ``./ripe-atlas-software-probe/build-config/debian/bin/make-deb``
-- Install this .deb file: ``dpkg -i atlasswprobe-??????.deb``
+(Please note if you are running Ubuntu it make be required to checkout the devel branch of this repo. If this is the case and the .deb build does not complete without failing this is the command sequence to follow;
+ * ``cd ripe-atlas-software-probe`` << this will change into the root directory of the git repo that you have clone
+ * ``git checkout devel`` << this will checkout the DEVEL branch instead of the MASTER branch
+ * ``git submodule update`` << this will update the submodule within this branch
+ * ``cd ..`` << this take you back to where you started
+ * ``./ripe-atlas-software-probe/build-config/debian/bin/make-deb`` << this will retry the build 
+- Install this .deb file: ``sudo dpkg -i atlasswprobe-??????.deb``
 - The public key is stored in ``/var/atlas-probe/etc/probe_key.pub``


### PR DESCRIPTION
Updated the Debian related install instructions section to explicitly include sudo where needed plus a new subsection in the case of Ubuntu installs where the build of the .deb may fail - as per comments on Slack in the Deployathon.