### PR TITLE
Update INSTALL.rst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ To create a deb for Debian or Debian-based distros
 
 Currently only the Debian Build system includes support for amd64, arm64, and armhf.
 
-- Get the needed tools: ``sudo apt update && sudo apt install git tar fakeroot libssl-dev libcap2-bin autoconf automake libtool build-essential``
+- Get the needed tools: ``sudo apt update && sudo apt install git tar fakeroot libssl-dev libcap2-bin autoconf automake libtool build-essential libtool make``
 - Clone the repo: ``git clone --recursive https://github.com/RIPE-NCC/ripe-atlas-software-probe.git``
 - Build the needed .deb file in the current working directory: ``./ripe-atlas-software-probe/build-config/debian/bin/make-deb``
 (Please note if you are running Ubuntu it may be required to checkout the devel branch of this repo. If this is the case and the .deb build does not complete without failing this is the command sequence to follow before trying the install of the .deb);


### PR DESCRIPTION
Updated to add `libtool` and `make` to prerequisites.

Without these, attempting to build on Debian will fail with erroneous errors.

Failure to install `libtool` will produce "configure.ac:129: error: possibly undefined macro: AC_PROG_LIBTOOL"

Failure to install `make` will produce "config.status: error: Something went wrong bootstrapping makefile fragments
    for automatic dependency tracking."

After installing `libtool` and `make`, the errors automagically disappear.