### PR TITLE
openwrt-sw-probe: Simulate reboot_probe with service restart

### DIFF
--- a/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
+++ b/bin/arch/openwrt-sw-probe/openwrt-sw-probe-common.sh
@@ -16,3 +16,9 @@ log_status()
 	date_now="$(date +'%D %H:%M:%S')"
 	echo "$date_now $state" >>/tmp/log/ripe_sw_probe
 }
+
+# Simulate reboot request as a restart of the atlas service
+reboot_probe()
+{
+	service atlas restart
+}


### PR DESCRIPTION
There is a long lasting problem when remote send a reboot_probe request but openwrt software probe have this not declared.

Not defining a real reboot_probe is intentional since we don't want the probe to be actually rebooted and cause problem to the user but ignoring the command and doing nothing is wrong. The script except the probe to be reboot and doesn't do anything resulting the the cron loop to be stuck in a waiting state (waiting for a rereg) and nothing actually sent to the remote servers.

The result is the probe flagged as connected (due to the reg completed= but measurement never done as nothing is sent.

To fix this, we simulate a probe_reboot by restarting the atlas service. The init.d script take care of closing any ssh connection/tunnel and clean the run directory effectively simulating a reboot.

With the following implementation the measurement scripts can recover and start again after a probe_reboot request.