### PR TITLE
replace source with POSIX-compliant .

### DIFF
--- a/bin/ATLAS
+++ b/bin/ATLAS
@@ -20,11 +20,11 @@ fi
 
 . $BIN_DIR/common.sh
 
-source $ATLAS_STATIC/bin/support.lib.sh
-source $ATLAS_STATIC/bin/class.lib.sh
-source $ATLAS_STATIC/bin/array.lib.sh
-source $ATLAS_STATIC/bin/json.lib.sh
-source $ATLAS_STATIC/bin/atlas_log.lib.sh
+. $ATLAS_STATIC/bin/support.lib.sh
+. $ATLAS_STATIC/bin/class.lib.sh
+. $ATLAS_STATIC/bin/array.lib.sh
+. $ATLAS_STATIC/bin/json.lib.sh
+. $ATLAS_STATIC/bin/atlas_log.lib.sh
 
 # config variables
 if [ $(config_lookup RXTXRPT no) = yes ]


### PR DESCRIPTION
`.` is a POSIX-compliant command, but `source` is not. Debian 10's `sh` does not recognize `source`, which causes some error messages to be printed out during probe startup.