### PR TITLE
Fix package name (libssl1 -> libssl1.1)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- libssl3 | libssl1,
+ libssl3 | libssl1.1,
  net-tools,
  openssh-client,
 Section: net


### PR DESCRIPTION
As title. See https://packages.debian.org/bullseye/libssl1.1.

Fixes #104.