### PR TITLE
Fix github organization url

### DIFF
--- a/rhel/ripe-atlas-anchor.spec
+++ b/rhel/ripe-atlas-anchor.spec
@@ -66,7 +66,7 @@ rm -rf %{_builddir}/%{build_dirname}
 echo "Getting Sources..."
 
 %{!?git_tag:%define git_tag master}
-%{!?git_source:%define git_source https://github.com/RIPE_NCC}
+%{!?git_source:%define git_source https://github.com/RIPE-NCC}
 
 git clone -b %{git_tag} %{git_source}/%{git_repo}.git %{_builddir}/%{build_dirname}
 

--- a/rhel/ripe-atlas-probe.spec
+++ b/rhel/ripe-atlas-probe.spec
@@ -76,7 +76,7 @@ rm -rf %{_builddir}/%{build_dirname}
 echo "Getting Sources..."
 
 %{!?git_tag:%define git_tag master}
-%{!?git_source:%define git_source https://github.com/RIPE_NCC}
+%{!?git_source:%define git_source https://github.com/RIPE-NCC}
 
 git clone -b %{git_tag} %{git_source}/%{git_repo}.git %{_builddir}/%{build_dirname}
 


### PR DESCRIPTION
There is a typo in url of github in rhel spec files.
Tested and works.