### PR TITLE
Update telnetd.c to add missing include

### DIFF
--- a/probe-busybox/networking/telnetd.c
+++ b/probe-busybox/networking/telnetd.c
@@ -120,6 +120,7 @@
 #include "common_bufsiz.h"
 #include <syslog.h>
 #include <sys/mount.h>
+#include <sys/reboot.h>
 #include "atlas_path.h"
 
 #if DEBUG


### PR DESCRIPTION
`ripe-atlas-software-probe` will not compile in Alpine Linux 3.21 due to a missing include:

```
networking/telnetd.c: In function 'telnetd_main':
networking/telnetd.c:952:32: warning: declaration of 'tv' shadows a previous local [-Wshadow]
  952 |                 struct timeval tv;
      |                                ^~
networking/telnetd.c:809:24: note: shadowed declaration is here
  809 |         struct timeval tv;
      |                        ^~
networking/telnetd.c:1181:33: error: implicit declaration of function 'reboot' [-Wimplicit-function-declaration]
 1181 |                                 reboot(LINUX_REBOOT_CMD_RESTART);
      |                                 ^~~~~~
networking/telnetd.c:809:24: warning: unused variable 'tv' [-Wunused-variable]
  809 |         struct timeval tv;
      |                        ^~
make[2]: *** [scripts/Makefile.build:198: networking/telnetd.o] Error 1
make[1]: *** [Makefile:755: networking] Error 2
make: *** [Makefile:470: install-recursive] Error 1
```

This adds the missing `#include <sys/reboot.h>` to `telnetd.c`.