### PR TITLE
Set Atlas-specific ref-id in probes' NTP client packets

### DIFF
--- a/probe-busybox/eperd/ntp.c
+++ b/probe-busybox/eperd/ntp.c
@@ -543,6 +543,7 @@ static void send_pkt(struct ntpstate *state)
 	}
 
 	ntphdr->ntp_flags= (NTP_VERSION << NTP_VERSION_SHIFT) | NTP_MODE_CLIENT;
+	ntphdr->ntp_reference_id= htonl(0x52495045);  /* "RIPE" */
 
 	gettimeofday(&state->xmit_time, NULL);
 


### PR DESCRIPTION
For easier identification on the server side, as suggested in the NTP Pool forum (https://community.ntppool.org/t/site-to-evaluate-ntp-servers/3931/4). "Atlas" is too long, so the proposal is to use "RIPE".