### PR TITLE
Add libssl3t64 for Debian 13

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Depends:
  bash,
  ${shlibs:Depends},
  ${misc:Depends},
- libssl3 | libssl1.1,
+ libssl3t64 | libssl3 | libssl1.1,
  net-tools,
  openssh-client,
  psmisc,


### PR DESCRIPTION
As title. Fixes #138 